### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, build, deploy-pages]
     if: always() && (needs.test.result == 'success' && needs.build.result == 'success')
-    
+    permissions: {}
     steps:
       - name: 🎯 Success Notification
         run: |


### PR DESCRIPTION
Potential fix for [https://github.com/sebhosting/seb-ultra-stack/security/code-scanning/9](https://github.com/sebhosting/seb-ultra-stack/security/code-scanning/9)

To address the issue, we should add an explicit `permissions:` block to the `notify` job to restrict the GITHUB_TOKEN. Since the `notify` job only runs echo commands and does not require any access to the repository, the most secure configuration is to set all permissions to none:

```yaml
permissions: {}
```

This block should be added just below the `runs-on:`/`if:`/`needs:` lines and before the `steps:` definition in the `notify` job (after line 163), matching how permissions are scoped for other jobs in this workflow. No new methods, imports, or definitions are needed—just the single config block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
